### PR TITLE
loadingの実装

### DIFF
--- a/app/template/mioshop/default_frame.twig
+++ b/app/template/mioshop/default_frame.twig
@@ -51,8 +51,12 @@
 
 </head>
 <body id="page_{{ app.request.get('_route') }}" class="{{ body_class|default('other_page') }}">
+  <!--loading-->
+  <div class="loading">
+    <img src="{{ app.config.front_urlpath }}/img/icon/logoanime_a.gif">
+  </div>
+  <!--loading end-->
   <div id="wrapper">
-
     <header id="header">
       <div class="container inner">
         {# ▼HeaderInternal COLUMN #}
@@ -160,6 +164,7 @@
   <script src="{{ app.config.front_urlpath }}/js/vendor/slick.min.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
   <script src="{{ app.config.front_urlpath }}/js/function.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
   <script src="{{ app.config.front_urlpath }}/js/eccube.js?v={{ constant('Eccube\\Common\\Constant::VERSION') }}"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"></script>
   <script>
   $(function () {
     $('#drawer').append($('.drawer_block').clone(true).children());
@@ -173,10 +178,18 @@
     });
   });
   </script>
+<!-- original / loading
+============================================= -->
+<script src="{{ app.config.front_urlpath }}/js/common/compornents/loading.js"></script>
 <!-- original
 ============================================= -->
 <script src="{{ app.config.front_urlpath }}/js/common/compornents/tmp_pickup.js"></script>
 <script src="{{ app.config.front_urlpath }}/js/common/compornents/tmp_criate_name.js"></script>
+<script src="{{ app.config.front_urlpath }}/js/common/compornents/tmp_criate_name.js"></script>
+<!-- 動画遅延読み込み -->
+<script src="https://cdn.jsdelivr.net/npm/lazysizes@5.2.0/lazysizes.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/lazysizes@5.2.0/plugins/unveilhooks/ls.unveilhooks.min.js"></script>
+<!-- / 動画遅延読み込み -->
 {% block javascript %}{% endblock %}
 </body>
 </html>

--- a/html/template/mioshop/css/original/block/block_common.css
+++ b/html/template/mioshop/css/original/block/block_common.css
@@ -189,4 +189,7 @@
 .mio #sideNavigation .official_block .text_link_image {
   width: 30px;
 }
+
+@import url("tmp_loading.css");
+
 /*# sourceMappingURL=block_common.css.map */

--- a/html/template/mioshop/css/original/block/tmp_loading.css
+++ b/html/template/mioshop/css/original/block/tmp_loading.css
@@ -1,0 +1,19 @@
+@charset "utf-8";
+.loading {
+    width: 100%;
+    height: 100%;
+    background: #000;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 20000;
+}
+
+.loading img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    margin: auto;
+}

--- a/html/template/mioshop/js/common/compornents/loading.js
+++ b/html/template/mioshop/js/common/compornents/loading.js
@@ -1,0 +1,21 @@
+// Cookie
+$(function () { // 1回目のアクセス
+    if ($.cookie("access") == undefined) { // alert("初回です");
+        $.cookie("access", "onece");
+        $(".loading").css("display", "block")
+
+        timer();
+        // 2回目以降
+    } else {
+        $(".loading").css("display", "none")
+        // alert("二回目以降です");
+    }
+});
+
+function timer() {
+    setTimeout('stopload()', 5700);
+}
+
+function stopload() {
+    $('.loading').css('display', 'none');
+}

--- a/html/user_data/test_page.twig
+++ b/html/user_data/test_page.twig
@@ -1,0 +1,72 @@
+{#
+This file is part of EC-CUBE
+
+Copyright(c) 2000-2015 LOCKON CO.,LTD. All Rights Reserved.
+
+http://www.lockon.co.jp/
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+#}
+{% extends 'default_frame.twig' %}
+
+{% set body_class = 'product_page' %}
+
+{% block main %}
+	<div id="contents" class="main_only">
+        <!--loading-->
+        <div class="loading">
+            <img src="{{ app.config.front_urlpath }}/img/icon/logoanime_a.gif">
+        </div>
+        <!--loading end-->
+        <div class="main_visual">
+            <div class="item">
+                <video id="video" preload="none" muted loop autoplay playsinline data-poster="" class="lazyload">
+                    <source src="{{ app.config.front_urlpath }}/img/movie/mv.mp4" type="video/mp4">
+                </video>
+            </div>
+        </div>
+        <script>
+            // Cookie
+            $(function () {
+                if (sessionStorage.getItem('access')) {
+                    console.log('2回目以降のアクセスです');
+                    $(".loading").css("display", "none");
+                    $('#video').get(0).play()
+                } else {
+                    console.log('初回アクセスです');
+                    sessionStorage.setItem('access', 0);
+                    $('.main_visual').css('display', 'none');
+                    $(".loading").css("display", "block");
+                }
+            });
+
+            $(window).load(function () { //全ての読み込みが完了したら実行
+              $('.loading').delay(900).fadeOut(800);
+              $('.main_visual').css('display', 'block');
+            });
+
+            //10秒たったら強制的にロード画面を非表示
+            $(function () {
+                setTimeout('stopload()', 5000);
+            });
+
+            function stopload() {
+                $('.main_visual').css('display', 'block');
+                $('.loading').delay(900).fadeOut(800);
+            }
+
+        </script>
+	</div>
+{% endblock %}


### PR DESCRIPTION
## ゴール
・トップページ初回訪問時にのみ、ローディングを表示したい
トップページ
https://mioofficial.jp/

## 参考資料
https://gimmicklog.com/jquery/278/
https://qiita.com/kfunnytokyo/items/8c7777fa28fef10782d6

## 課題
・スマホで表示すると初期表示が重い
・メインビジュアルのvideoタグが原因？
・動画を画像にするとスムーズに動く

## 検証用ページ
下記の検証用ページで色々検証中
再現が出来たらトップページに反映する
https://mioofficial.jp/user_data/test_page